### PR TITLE
Protect flash from wear out by Wifi.begin()

### DIFF
--- a/code/CO2_monitor.ino
+++ b/code/CO2_monitor.ino
@@ -215,6 +215,13 @@ void setup(){
      default, try to act as both, client and access-point, and could cause
      network-issues with other WiFi-devices on your WiFi-network. */
   WiFi.mode(WIFI_STA);
+  // Set Wifi persistent to false,
+  // otherwise on every WiFi.begin the
+  // ssid and password will be written to
+  // the same area in the flash which will
+  // destroy the device in the long run
+  // See: https://github.com/esp8266/Arduino/issues/1054
+  WiFi.persistent(false);
   WiFi.begin(ssid, password);     // connect to Wi-Fi
   if (DEBUG == true)
     Serial.println("Connecting to WiFi");


### PR DESCRIPTION
Hi @alfkoehn,

I just saw your CCCS talk from rc3 and noticed that you are using an ESP8266.

A common problem that may occur when using Wifi.begin is that it can wear out the flash if called every once in a while (e.g. when the device is reset regularly).

Therefore it is useful to disable the persistent storage of the Wifi credentials.

For more details see: https://github.com/esp8266/Arduino/issues/1054